### PR TITLE
Fixed avg stars method in case of no rating

### DIFF
--- a/app/models/snack.rb
+++ b/app/models/snack.rb
@@ -11,8 +11,8 @@ class Snack < ApplicationRecord
   validates :category, presence: true
 
   def avg_snack_stars
-    snack_rating_array = Snack.find(id).snack_ratings
-    snack_stars_array = snack_rating_array.map(&:stars)
+    return 0 if snack_ratings.empty?
+    snack_stars_array = snack_ratings.map(&:stars)
     avg_stars_float = snack_stars_array.inject { |sum, el| sum + el }.to_f / snack_stars_array.size
     avg_stars_float.round(half: :up)
   end


### PR DESCRIPTION
Fixed 'avg_snack_stars' method, so that in case a snack has no rating, the method returns 0.  