### PR TITLE
Commented out line for compiling assets as an attempt to fix precompi…

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  # config.assets.compile = false
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 


### PR DESCRIPTION
- Asset pipeline is having an issue in production with katy.jpeg (code looks okay)
- Stack Overflow suggested commenting out a line in the config for production so that's what this request is