### PR TITLE
fixed stars for snack#show, home, category#show

### DIFF
--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -17,13 +17,17 @@
             <div>
               <h4 class="info"> <%= snack.name %> </h4>
               <div class="stars">
+              <% if snack.avg_snack_stars == 0 %>
+              No ratings yet!
+              <% else %>
                 <% (snack.avg_snack_stars).times do %>
                   <i class="fas fa-star"></i>
                 <% end %>
-                <% (1 - snack.avg_snack_stars).times do %>
+                <% (5 - snack.avg_snack_stars).times do %>
                   <i class="far fa-star"></i>
                 <% end %>
-              </div>
+              <% end %>
+            </div>
             </div>
             <%= image_tag("bobby", :alt=> "bananadeer", class: "bobby") %>
           </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -55,11 +55,15 @@
           <div>
             <h4 class="info"> <%= snack.name %> </h4>
             <div class="stars">
-              <% (snack.avg_snack_stars).times do %>
-                <i class="fas fa-star"></i>
-              <% end %>
-              <% (1 - snack.avg_snack_stars).times do %>
-                <i class="far fa-star"></i>
+              <% if snack.avg_snack_stars == 0 %>
+              No ratings yet!
+              <% else %>
+                <% (snack.avg_snack_stars).times do %>
+                  <i class="fas fa-star"></i>
+                <% end %>
+                <% (5 - snack.avg_snack_stars).times do %>
+                  <i class="far fa-star"></i>
+                <% end %>
               <% end %>
             </div>
           </div>

--- a/app/views/snacks/show.html.erb
+++ b/app/views/snacks/show.html.erb
@@ -17,7 +17,18 @@
           <h3 style="font-size: 38px;"><%= @snack.name %></h3>
           <div class="icons" style="display: flex;
             justify-content: space-between;">
-            <h3 class="snack-show-card-stars"><i class="fas fa-star"></i><i class="fas fa-star"></i><i class="fas fa-star"></i></h3>
+            <h3 class="snack-show-card-stars">
+              <% if @snack.avg_snack_stars == 0 %>
+              No ratings yet!
+              <% else %>
+                <% (@snack.avg_snack_stars).times do %>
+                  <i class="fas fa-star"></i>
+                <% end %>
+                <% (5 - @snack.avg_snack_stars).times do %>
+                  <i class="far fa-star"></i>
+                <% end %>
+              <% end %>
+            </h3>
             <%= link_to favorite_snack_path(@snack), method: :patch, remote: true do %>
               <div class="snack-show-card-heart">
                 <%= image_tag @heart, alt: "alttext", class: "snack-show-fixed-heart" %>


### PR DESCRIPTION
- Index cards for each snack now show stars according to rating.  
- I made it clearer that the ratings are out of 5, by displaying filled out stars for the actual rating they got, and displaying empty stars for ones they didn't.  For example, if a snack got a 3 rating, it'll display 3 filled out stars and 2 empty stars.  
- If a snack has no rating, it'll display 'no ratings yet!'