### PR TITLE
Tags are now accessible from all pages

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,6 +3,7 @@ class PagesController < ApplicationController
 
   def home
     @tags = ActsAsTaggableOn::Tag.most_used(8)
+    @tags = @tags.map { |tag| tag.name }
     @categories = Category.all
     @snacks = Snack.all
   end

--- a/app/controllers/snacks_controller.rb
+++ b/app/controllers/snacks_controller.rb
@@ -78,7 +78,7 @@ class SnacksController < ApplicationController
 
   def tagged
     if params[:tag].present?
-      @tag = ActsAsTaggableOn::Tag.find(params[:tag])
+      @tag = params[:tag]
       @snacks = Snack.tagged_with(@tag)
     else
       @snacks = Snack.all

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,19 +1,25 @@
 <div class="container-fluid">
   <div class="row no-gutters">
     <div class="col-4 px-1">
+      <%= link_to tagged_path(tag: 'popular') do  %>
       <div class="feature-card" style="background-image: radial-gradient(circle, rgba(249,214,217, 0.5), rgba(240,210,195, 0.5), rgba(219,209,181, 0.5), rgba(190,209,181, 0.5), rgba(161,206,193, 0.5)), url('<%= asset_path 'strawmilk.jpg' %>')">
         POPULAR
       </div>
+      <% end %>
     </div>
     <div class="col-4 px-1">
+      <%= link_to tagged_path(tag: 'seasonal') do  %>
       <div class="feature-card" style="background-image: radial-gradient(circle, rgba(249,214,217, 0.5), rgba(240,210,195, 0.5), rgba(219,209,181, 0.5), rgba(190,209,181, 0.5), rgba(161,206,193, 0.5)), url('<%= asset_path 'mikan.jpg' %>')">
         SEASONAL
       </div>
+      <% end %>
     </div>
     <div class="col-4 px-1">
+      <%= link_to tagged_path(tag: 'new') do  %>
       <div class="feature-card" style="background-image: radial-gradient(circle, rgba(249,214,217, 0.5), rgba(240,210,195, 0.5), rgba(219,209,181, 0.5), rgba(190,209,181, 0.5), rgba(161,206,193, 0.5)), url('<%= asset_path 'namadora.jpg' %>')">
         NEW
       </div>
+      <% end %>
     </div>
   </div>
   <div class="row center mt-4">
@@ -22,7 +28,7 @@
         <%= simple_form_for :search, url: snacks_path, method: "GET", html: { class: 'form-inline' } do |f| %>
           <%= f.input :query, input_html: { value: ""}, placeholder: "Try 'taiyaki'...", name: "search", label: false %>
         </div>
-        
+
         <div class="searchbutton">
           <button type="submit", { class="btn btn-search" } >
             <i class="fa fa-search" aria-hidden="true"></i>

--- a/app/views/shared/_tags.html.erb
+++ b/app/views/shared/_tags.html.erb
@@ -1,9 +1,13 @@
 <div class="d-flex flex-wrap justify-content-center">
-  <% tags.each do |tag| %>
-    <%= link_to tagged_path(tag: tag) do  %>
-      <div class="tag">
-        <p class= "tag-text"><%= tag %></p>
-      </div>
+  <% if tags.any? %>
+    <% tags.each do |tag| %>
+      <%= link_to tagged_path(tag: tag) do  %>
+        <div class="tag">
+          <p class= "tag-text"><%= tag %></p>
+        </div>
+      <% end %>
     <% end %>
+  <% else %>
+    <p>No snacks tagged</p>
   <% end %>
 </div>


### PR DESCRIPTION
- The problem was that I was passing the tags as instances in certain cases, when all I needed to pass was the tag name.  
- The featured cards also have links that go directly to their respective tag pages.  
- Unrelated but Important: I was going through some of the snack#show pages and it won't show up due to image path issues?  I'll post on Slack w more detail