### PR TITLE
Fixed snack add/remove buttons logic for trail#edit and trail#show

### DIFF
--- a/app/assets/stylesheets/components/_trail-toggle-edit-button.scss
+++ b/app/assets/stylesheets/components/_trail-toggle-edit-button.scss
@@ -5,3 +5,7 @@
 .fa-minus-circle {
   color: red;
 }
+
+.toggle-edit-trail-button {
+  font-size: 32px;
+}

--- a/app/controllers/trails_controller.rb
+++ b/app/controllers/trails_controller.rb
@@ -1,6 +1,6 @@
 class TrailsController < ApplicationController
   before_action :filter_snacks_params, only: [:update]
-  before_action :set_trail, only: [:show, :edit, :update, :destroy, :toggle_edit]
+  before_action :set_trail, only: [:show, :edit, :update, :destroy, :toggle_edit, :toggle_show]
   def index
     # once pundit is implemented this will likely change
     @trails = Trail.all
@@ -62,6 +62,21 @@ class TrailsController < ApplicationController
     else
       @trail.snacks << @snack
       @value = "true"
+    end
+    respond_to do |format|
+      format.js
+    end
+  end
+
+  def toggle_show
+    @snack = Snack.find(params[:snack])
+
+    if @trail.snacks.include?(@snack)
+      @trail.snacks.delete(@snack)
+      @value = "removed"
+    else
+      @trail.snacks << @snack
+      @value = "added"
     end
     respond_to do |format|
       format.js

--- a/app/controllers/trails_controller.rb
+++ b/app/controllers/trails_controller.rb
@@ -58,10 +58,10 @@ class TrailsController < ApplicationController
 
     if @trail.snacks.include?(@snack)
       @trail.snacks.delete(@snack)
-      @value = "false"
+      @value = "removed"
     else
       @trail.snacks << @snack
-      @value = "true"
+      @value = "added"
     end
     respond_to do |format|
       format.js

--- a/app/views/snacks/favorites.html.erb
+++ b/app/views/snacks/favorites.html.erb
@@ -3,7 +3,11 @@
   <% @snacks.each do |snack| %>
     <%= link_to snack, class: "mb-2" do %>
       <div class="favorite-card mt-2">
-        <%= cl_image_tag(snack.snack_images.first.image_path, :alt=> "cake") %>
+        <% if snack.snack_images.empty? %>
+          <%= image_tag "cake.jpg", class: "flex-grow-1 flex-image flex-left" %>
+        <% else %>
+          <%= cl_image_tag(snack.snack_images.first.image_path, :alt=> "cake") %>
+        <% end %>
         <div class="favorite-card-infos" style="display: flex; flex-direction: column; justify-content: space-between;">
           <div class="fav-info-stuff">
             <h2> <%= snack.name %></h2>

--- a/app/views/trails/_trail_edit_card.html.erb
+++ b/app/views/trails/_trail_edit_card.html.erb
@@ -10,10 +10,12 @@
         <% end %>
       </div>
     <% end %>
-    <%= link_to toggle_edit_trail_path(snack: snack, trail: @trail), method: :patch, remote: true do %>
-      <div class="toggle-edit-trail-button" id="toggle-button-<%= snack.id %>">
-        <i class="fas fa-<%= @trail.snacks.include?(snack) ? "minus" : "plus" %>-circle"></i>
-      </div>
+    <% if !@trail.snacks.include?(snack) %>
+      <%= link_to toggle_edit_trail_path(snack: snack, trail: @trail), method: :patch, remote: true do %>
+        <div class="toggle-edit-trail-button" id="toggle-button-<%= snack.id %>">
+          <i class="fas fa-plus-circle"></i>
+        </div>
+      <% end %>
     <% end %>
       <div class="snack-index-sub-card-2">
         <div class="sub-title mt-3">

--- a/app/views/trails/_trail_edit_card.html.erb
+++ b/app/views/trails/_trail_edit_card.html.erb
@@ -3,7 +3,11 @@
   <div class="snack-index-card-2">
     <%= link_to snack_path(snack) do %>
       <div class="snack-index-card-2-image">
-        <%= cl_image_tag snack.snack_images[0].image_path %>
+        <% if snack.snack_images.empty? %>
+          <%= image_tag "cake.jpg", class: "flex-grow-1 flex-image flex-left" %>
+        <% else %>
+          <%= cl_image_tag snack.snack_images[0].image_path %>
+        <% end %>
       </div>
     <% end %>
     <%= link_to toggle_edit_trail_path(snack: snack, trail: @trail), method: :patch, remote: true do %>

--- a/app/views/trails/_trail_edit_card.html.erb
+++ b/app/views/trails/_trail_edit_card.html.erb
@@ -12,8 +12,8 @@
     <% end %>
     <% if !@trail.snacks.include?(snack) %>
       <%= link_to toggle_edit_trail_path(snack: snack, trail: @trail), method: :patch, remote: true do %>
-        <div class="toggle-edit-trail-button" id="toggle-button-<%= snack.id %>">
-          <i class="fas fa-plus-circle"></i>
+        <div id="toggle-button-<%= snack.id %>">
+          <i class="fas fa-plus-circle toggle-edit-trail-button"></i>
         </div>
       <% end %>
     <% end %>

--- a/app/views/trails/_trail_show_card.html.erb
+++ b/app/views/trails/_trail_show_card.html.erb
@@ -1,47 +1,49 @@
 <% user_rating = user_rating || false %>
 <% snacks.each do |snack| %>
-  <div class="snack-index-card-2" id="toggle-card-<%= snack.id %>">
-    <%= link_to snack_path(snack) do %>
-      <div class="snack-index-card-2-image">
-        <% if snack.snack_images.empty? %>
-          <%= image_tag "cake.jpg", class: "flex-grow-1 flex-image flex-left" %>
-        <% else %>
-          <%= cl_image_tag snack.snack_images[0].image_path %>
-        <% end %>
-      </div>
-    <% end %>
-    <%= link_to toggle_show_trail_path(snack: snack, trail: @trail), method: :patch, remote: true do %>
-      <div class="toggle-edit-trail-button" id="toggle-button-<%= snack.id %>">
-        <i class="fas fa-<%= @trail.snacks.include?(snack) ? "minus" : "plus" %>-circle"></i>
-      </div>
-    <% end %>
-      <div class="snack-index-sub-card-2">
-        <div class="sub-title mt-3">
-          <h4> <%= snack.name %> </h4>
+  <div id="toggle-card-<%= snack.id %>">
+    <div class="snack-index-card-2">
+      <%= link_to snack_path(snack) do %>
+        <div class="snack-index-card-2-image">
+          <% if snack.snack_images.empty? %>
+            <%= image_tag "cake.jpg", class: "flex-grow-1 flex-image flex-left" %>
+          <% else %>
+            <%= cl_image_tag snack.snack_images[0].image_path %>
+          <% end %>
         </div>
-        <div class="bottom-info">
-          <div class="stars">
-            <% if user_rating %>
-              <% snack_rating = current_user.snack_ratings.find_by(snack: snack) %>
-              <% (snack_rating.stars).times do %>
-                <i class="fas fa-star"></i>
-              <% end %>
-              <% (5 - snack_rating.stars).times do %>
-                <i class="far fa-star"></i>
-              <% end %>
-            <% elsif snack.avg_snack_stars == 0 %>
-              No ratings yet!
-            <% else %>
-              <% (snack.avg_snack_stars).times do %>
-                <i class="fas fa-star"></i>
-              <% end %>
-              <% (5 - snack.avg_snack_stars).times do %>
-                <i class="far fa-star"></i>
-              <% end %>
-            <% end %>
+      <% end %>
+      <%= link_to toggle_show_trail_path(snack: snack, trail: @trail), method: :patch, remote: true do %>
+        <div class="toggle-edit-trail-button" id="toggle-button-<%= snack.id %>">
+          <i class="fas fa-<%= @trail.snacks.include?(snack) ? "minus" : "plus" %>-circle"></i>
+        </div>
+      <% end %>
+        <div class="snack-index-sub-card-2">
+          <div class="sub-title mt-3">
+            <h4> <%= snack.name %> </h4>
           </div>
-          <%= image_tag("bobby", class: "bobby") unless user_rating %>
+          <div class="bottom-info">
+            <div class="stars">
+              <% if user_rating %>
+                <% snack_rating = current_user.snack_ratings.find_by(snack: snack) %>
+                <% (snack_rating.stars).times do %>
+                  <i class="fas fa-star"></i>
+                <% end %>
+                <% (5 - snack_rating.stars).times do %>
+                  <i class="far fa-star"></i>
+                <% end %>
+              <% elsif snack.avg_snack_stars == 0 %>
+                No ratings yet!
+              <% else %>
+                <% (snack.avg_snack_stars).times do %>
+                  <i class="fas fa-star"></i>
+                <% end %>
+                <% (5 - snack.avg_snack_stars).times do %>
+                  <i class="far fa-star"></i>
+                <% end %>
+              <% end %>
+            </div>
+            <%= image_tag("bobby", class: "bobby") unless user_rating %>
+          </div>
         </div>
-      </div>
+    </div>
   </div>
 <% end %>

--- a/app/views/trails/_trail_show_card.html.erb
+++ b/app/views/trails/_trail_show_card.html.erb
@@ -3,7 +3,11 @@
   <div class="snack-index-card-2" id="toggle-card-<%= snack.id %>">
     <%= link_to snack_path(snack) do %>
       <div class="snack-index-card-2-image">
-        <%= cl_image_tag snack.snack_images[0].image_path %>
+        <% if snack.snack_images.empty? %>
+          <%= image_tag "cake.jpg", class: "flex-grow-1 flex-image flex-left" %>
+        <% else %>
+          <%= cl_image_tag snack.snack_images[0].image_path %>
+        <% end %>
       </div>
     <% end %>
     <%= link_to toggle_show_trail_path(snack: snack, trail: @trail), method: :patch, remote: true do %>

--- a/app/views/trails/_trail_show_card.html.erb
+++ b/app/views/trails/_trail_show_card.html.erb
@@ -1,0 +1,43 @@
+<% user_rating = user_rating || false %>
+<% snacks.each do |snack| %>
+  <div class="snack-index-card-2" id="toggle-card-<%= snack.id %>">
+    <%= link_to snack_path(snack) do %>
+      <div class="snack-index-card-2-image">
+        <%= cl_image_tag snack.snack_images[0].image_path %>
+      </div>
+    <% end %>
+    <%= link_to toggle_show_trail_path(snack: snack, trail: @trail), method: :patch, remote: true do %>
+      <div class="toggle-edit-trail-button" id="toggle-button-<%= snack.id %>">
+        <i class="fas fa-<%= @trail.snacks.include?(snack) ? "minus" : "plus" %>-circle"></i>
+      </div>
+    <% end %>
+      <div class="snack-index-sub-card-2">
+        <div class="sub-title mt-3">
+          <h4> <%= snack.name %> </h4>
+        </div>
+        <div class="bottom-info">
+          <div class="stars">
+            <% if user_rating %>
+              <% snack_rating = current_user.snack_ratings.find_by(snack: snack) %>
+              <% (snack_rating.stars).times do %>
+                <i class="fas fa-star"></i>
+              <% end %>
+              <% (5 - snack_rating.stars).times do %>
+                <i class="far fa-star"></i>
+              <% end %>
+            <% elsif snack.avg_snack_stars == 0 %>
+              No ratings yet!
+            <% else %>
+              <% (snack.avg_snack_stars).times do %>
+                <i class="fas fa-star"></i>
+              <% end %>
+              <% (5 - snack.avg_snack_stars).times do %>
+                <i class="far fa-star"></i>
+              <% end %>
+            <% end %>
+          </div>
+          <%= image_tag("bobby", class: "bobby") unless user_rating %>
+        </div>
+      </div>
+  </div>
+<% end %>

--- a/app/views/trails/show.html.erb
+++ b/app/views/trails/show.html.erb
@@ -15,7 +15,7 @@
     <h3>Snacks to Snack</h3>
   </div>
     <div class="row d-flex">
-      <%= render "snacks/index-card", snacks: @trail.snacks %>
+      <%= render "trails/trail_show_card", snacks: @trail.snacks %>
     </div>
     <div class="row">
       <div class="map-container">

--- a/app/views/trails/toggle_edit.js.erb
+++ b/app/views/trails/toggle_edit.js.erb
@@ -3,10 +3,8 @@ var snack_id = '<%= j @snack.id.to_s %>'
 
 function toggleEdit() {
  const button = document.querySelector(`#toggle-button-${snack_id}`);
-  if (value === "true") {
-    button.innerHTML = '<i class="fas fa-minus-circle"></i>';
-  } else {
-    button.innerHTML = '<i class="fas fa-plus-circle"></i>';
+  if (value === "added") {
+    button.innerHTML = '';
   }
 }
 

--- a/app/views/trails/toggle_show.js.erb
+++ b/app/views/trails/toggle_show.js.erb
@@ -1,0 +1,11 @@
+var value = '<%= j @value %>'
+var snack_id = '<%= j @snack.id.to_s %>'
+
+function toggleShowCard() {
+ const card = document.querySelector(`#toggle-card-${snack_id}`);
+  if (value === "removed") {
+    card.innerHTML = '';
+  }
+}
+
+toggleShowCard();

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
   resources :trails do
     member do
       patch 'toggle_edit', to: 'trails#toggle_edit'
+      patch 'toggle_show', to: 'trails#toggle_show'
     end
   end
 


### PR DESCRIPTION
- Trail#edit: A user can only add snacks to a trail.
- Trail#show: A user can only remove snacks from a trail.  

Things to work on:
- Styling for buttons (put them in top-right of each snack index card)
- When a user removes a snack from a trial in trail#show, should the map markers update accordingly?  The removed snack's location is still displayed
- In trail#edit, should there be some sort of confirmation that the snack has been added?  For now, the plus sign disappears from the card but that's it.  Maybe add a check mark?