### PR TITLE
Fixed styling for the add/remove button on Trail#show and trail#edit

### DIFF
--- a/app/assets/stylesheets/components/_trail-toggle-edit-button.scss
+++ b/app/assets/stylesheets/components/_trail-toggle-edit-button.scss
@@ -1,11 +1,22 @@
 .fa-plus-circle {
-  color: green;
+  color: $teal;
+  transition: color 0.3s;
+  &:hover {
+    color: $green;
+  }
 }
 
 .fa-minus-circle {
-  color: red;
+  color: $light-pink;
+  transition: color 0.3s;
+  &:hover {
+    color: $red;
+  }
 }
 
 .toggle-edit-trail-button {
   font-size: 32px;
+  position: absolute;
+  top: 0;
+  right: 10px;
 }


### PR DESCRIPTION
- Buttons are now positioned in the top right of each snack index card
- In desktop, the color becomes more vibrant (green or red) when you hover over the button.